### PR TITLE
Get WNS logs using API.

### DIFF
--- a/packages/console-client/package.json
+++ b/packages/console-client/package.json
@@ -35,7 +35,7 @@
     "@material-ui/core": "^4.10.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
-    "@wirelineio/registry-client": "^0.4.8",
+    "@wirelineio/registry-client": "^0.4.9",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link-http": "^1.5.17",

--- a/packages/console-client/src/resolvers.js
+++ b/packages/console-client/src/resolvers.js
@@ -52,11 +52,12 @@ export const createResolvers = config => {
       wns_log: async () => {
         log('WNS log...');
 
-        // TODO(burdon): Use Registry API rather than from CLI?
+        const data = await registry.getLogs();
+
         return {
           __typename: 'JSONLog',
           timestamp: timestamp(),
-          log: []
+          log: data
         };
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3267,12 +3267,13 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wirelineio/registry-client@^0.4.8":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@wirelineio/registry-client/-/registry-client-0.4.8.tgz#05baf614ed28c25daaa20335359955b0a153a509"
-  integrity sha512-kxf4Zj3dr+q+dW++N2TUAZz7h7LLE/8RU31c7mUEwy9ZbZXXPcAF0voq8985FTCUmSc4Z5t9b77hvpFqFn5lLA==
+"@wirelineio/registry-client@^0.4.9":
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/@wirelineio/registry-client/-/registry-client-0.4.9.tgz#8e0166c67d74d634294076cff73b7cff5cee40d8"
+  integrity sha512-n9oecUGU01+SUvdrB+/1LCbAQT+jiIG3pfZj+JLU4teou17ZxaEcMbzpFamWO2IVXZP0751y6Va42K4IFE7e9w==
   dependencies:
     "@babel/runtime" "^7.0.0"
+    "@wirelineio/wns-schema" "^0.1.0"
     bech32 "^1.1.3"
     bip32 "^2.0.5"
     bip39 "^2.5.0"
@@ -3290,6 +3291,11 @@
     multihashing-async "^0.8.0"
     ripemd160 "^2.0.2"
     secp256k1 "^3.6.2"
+
+"@wirelineio/wns-schema@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@wirelineio/wns-schema/-/wns-schema-0.1.0.tgz#61afc98e0a3e89a5d4ad3ef1d84f50b199224356"
+  integrity sha512-MetSYFR7OS54hR2tGmFnzGeK5vwqJfBI2kZXmYHKcdj5EyJXheMg9XP3LUwVLVgRe7gOCoQqBstAYl1cL1FdHg==
 
 "@wry/context@^0.4.0":
   version "0.4.4"


### PR DESCRIPTION
Get logs using WNS API.

![Screen Shot 2020-05-26 at 15 35 25](https://user-images.githubusercontent.com/14833/82888087-88deba00-9f66-11ea-9a30-8a8b9c38897d.png)

Tested on localhost, also needs `node1.dxos.network` to be updated to latest WNS code.

WNS schema is available in the `"@wirelineio/wns-schema" "^0.1.0"` package. 